### PR TITLE
fix: generate sboms and trim crate extras

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,8 @@ jobs:
 
       - name: Generate SBOM
         run: |
-          cargo cyclonedx --format json --spec-version 1.5 > sbom.json
-          cargo cyclonedx --format xml --spec-version 1.5 > sbom.xml
+          cargo cyclonedx --format json --spec-version 1.5 --override-filename sbom
+          cargo cyclonedx --format xml --spec-version 1.5 --override-filename sbom
 
       - name: Upload security artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,17 @@ exclude = [
   ".gitignore",
   ".samoyed/",
   ".docs/",
-  "src/unit_tests/",
+  ".assets/",
+  ".cargo/",
   ".markdownlint.json",
   ".tarpaulin.toml",
+  ".release-plz.toml",
+  "clippy.toml",
   "CLAUDE.md",
-  "samoyed.toml",
+  "AGENTS.md",
+  "flake.nix",
+  "flake.lock",
+  "tmp/",
 ]
 
 


### PR DESCRIPTION
## Summary
- call `cargo cyclonedx` with `--override-filename` so the workflow produces non-empty `sbom.json`/`sbom.xml`
- expand `package.exclude` to drop dot-asset, Nix, lint, and temp files from the published crate

## Testing
- cargo fmt --check
- cargo clippy --all-targets --all-features
- cargo test -- --test-threads=1
- cargo cyclonedx --format json --spec-version 1.5 --override-filename sbom
- cargo cyclonedx --format xml --spec-version 1.5 --override-filename sbom
