### PR TITLE
fix: correct release-plz PR body template variable names

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -49,8 +49,9 @@ This PR was automatically created by [release-plz](https://github.com/MarcoIeni/
 
 ### 🔄 Merge Instructions
 When you merge this PR, the following will happen automatically:
+1. New git tags will be created:
 {% for r in releases -%}
-1. A new git tag `v{{ r.next_version }}` will be created for {{ r.package }}
+   - `v{{ r.next_version }}` for {{ r.package }}
 {% endfor -%}
 2. GitHub release will be published with binaries
 3. The crate will be published to crates.io


### PR DESCRIPTION
The PR body template was using incorrect variable names (version, prev_version, changelog) which caused release-plz to fail with "Variable 'version' not found in context". Updated to use the correct releases[0] array syntax (next_version, previous_version, changelog) and added conditional rendering for changelog and breaking changes.